### PR TITLE
Jenkins Master is no longer provides `COMMIT_MESSAGE` variable. 

### DIFF
--- a/vars/containsCommitMessage.groovy
+++ b/vars/containsCommitMessage.groovy
@@ -1,8 +1,3 @@
 def call(String message) {
-  def lastCommitMessage = env['COMMIT_MESSAGE'].isEmpty() ? getCommitMessage() : env['COMMIT_MESSAGE']
-  if (lastCommitMessage.contains(message)) {
-    echo "Found \'${message}\' in git latest commit message"
-    return true
-  }
-  return false
+  return getCommitMessage().contains(message)
 }


### PR DESCRIPTION
### What's Happened
- Jenkins Master is no longer provides `COMMIT_MESSAGE` variable. 
- I replace getting the commit message from `env.COMMIT_MESSAGE` to `getCommitMessage()` which it calls git command using shell script. 

### Insight 
- This will work with all Jenkins master versions because it uses the `git` command directly. 
https://github.com/nimblehq/jenkins-pipeline-shared/blob/master/vars/getCommitMessage.groovy