### PR TITLE
Check changes from the last skipping-ci commit to the last commit

### DIFF
--- a/vars/shouldContinueSkippingCI.groovy
+++ b/vars/shouldContinueSkippingCI.groovy
@@ -1,0 +1,24 @@
+def call(String author) {
+  /* Note: The idea of this function
+	We usually create new pull requests after pulling translation and bumping version 
+	before releasing new version of the application.
+	We also mark those pull requests with [skip-ci] to avoid re-building the whole pipeline.
+	The problem is that we sometimes need to add more feature after commiting [skip-ci].
+	By checking changes from the lastest [skip-ci] commit (which is made by the CI author)
+	to the last commit, we can solve above issue.
+	*/
+
+	// Get the last commit Hash ID
+	String lastCommitScript = "git log --pretty=format:%H -1"
+	String lastCommitID = sh(script: lastCommitScript, returnStdout: true) as String
+
+	// Get the last skip commit Hash ID, which is made by the author (Ex: dev@nimblehq.co)
+	String lastSkipCommitScript = "git log --pretty=format:%H --author=${author} -1"
+	String lastSkipCommitID = sh(script: lastSkipCommitScript, returnStdout: true) as String
+
+	// Get the lastest commit information since the last time skipping CI by the author (Ex: dev@nimblehq.co)
+	String latestCommitsInfoScript = "git log --cherry-pick ${lastCommitID}...${lastSkipCommitID}"
+	String latestCommitsInfo = sh(script: latestCommitsInfoScript, returnStdout: true) as String
+
+  return latestCommitsInfo.contains("[skip-ci]")
+}


### PR DESCRIPTION
## What happened

- We usually create new pull requests after pulling translation and bumping the version number before releasing a new version of the application.
- We also mark those pull requests with [skip-ci] to avoid re-building the whole pipeline.
- The problem is that we sometimes need to add more features after committing `[skip-ci]`. If we use the function `shouldSkipCI` for this case, then we cannot re-building the pipeline, even though the new commits do not contain `[skip-ci]`.
 
## Insight

- The pulling translation commit and the bumping the version number commit are usually made automatically by dev@nimblehq.co.
- By checking changes from the lastest [skip-ci] commit (which is made by the CI author) to the last commit, we can solve the above issue.
